### PR TITLE
fix: Resolve the button issue below every code block by pinning just-the-docs to v0.3.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.github_repo }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-remote_theme: pmarsceill/just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.3.3
+
 title: Konveyor Move2Kube
 description: A tool that accelerates the process of re-platforming to Kubernetes
 # baseurl: "/" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
The v0.4.x of just-the-docs theme which were released Feb 2023 onward have potentially breaking changes, like the button which is appearing below every code block in Move2Kube's website. So, currently I have pinned the version to v0.3.3 of just-the-docs.

With v0.4.x -
<img width="780" alt="Screenshot 2023-04-04 at 10 48 16 AM" src="https://user-images.githubusercontent.com/14867323/229693794-d6d89194-de2c-4aef-9718-2c4fa5f2d55b.png">

With v0.3.3 -
<img width="809" alt="Screenshot 2023-04-04 at 10 50 46 AM" src="https://user-images.githubusercontent.com/14867323/229694146-ae9e0786-c35c-4b59-bffc-8cf3279a59e6.png">

https://akash-nayak.github.io/move2kube-website/#a-quick-start-with-move2kube