### PR TITLE
docs: fix the Move2Kube website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Move2Kube GitHub pages repo
 
-This repository holds the code that generates the [Move2Kube Project's web page](https://movekube.konveyor.io/).
+This repository holds the code that generates the [Move2Kube Project's web page](https://move2kube.konveyor.io/).
 
 ## Contributing
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,11 +83,6 @@ layout: table_wrappers
           </picture>
         </a>
         </div>
-        <div class="column">
-          <a href="https://move2kube.konveyor.io" class="icon-link">
-            <img alt="Move2Kube on Katacoda" src="{{ site.baseurl }}/assets/images/katacoda-icon.png" width="60" height="60" title="Katacoda">
-          </a>
-        </div>
       </div>
       <div class="row">
         <div class="column">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,7 +84,7 @@ layout: table_wrappers
         </a>
         </div>
         <div class="column">
-          <a href="https://www.katacoda.com/move2kube" class="icon-link">
+          <a href="https://move2kube.konveyor.io" class="icon-link">
             <img alt="Move2Kube on Katacoda" src="{{ site.baseurl }}/assets/images/katacoda-icon.png" width="60" height="60" title="Katacoda">
           </a>
         </div>

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -13,4 +13,4 @@ We also have a [VSCode extension](/installation/vscode-extension)
 
 ![Move2Kube Installation]({{ site.baseurl }}/assets/images/install.png)
 
-You can try out Move2Kube in [Katacoda](https://www.katacoda.com/move2kube).
+You can try out Move2Kube in [Katacoda](https://move2kube.konveyor.io).

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -12,5 +12,3 @@ Move2Kube can be consumed as a [command line tool](/installation/cli) or as a [w
 We also have a [VSCode extension](/installation/vscode-extension)
 
 ![Move2Kube Installation]({{ site.baseurl }}/assets/images/install.png)
-
-You can try out Move2Kube in [Katacoda](https://move2kube.konveyor.io).

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ Move2Kube is a tool that uses source files such as Docker Compose files or Cloud
 
 ## A quick start with Move2Kube
 
-With Move2Kube, generating the Kubernetes/OpenShift deployment files for your source platform files is now simple. You can try out Move2Kube in [Katacoda](https://www.katacoda.com/move2kube) or follow the steps mentioned below for trying out Move2Kube on your local machine.
+With Move2Kube, generating the Kubernetes/OpenShift deployment files for your source platform files is now simple. You can try out Move2Kube in [Katacoda](https://move2kube.konveyor.io) or follow the steps mentioned below for trying out Move2Kube on your local machine.
 
 
 1. Install Move2Kube

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ Move2Kube is a tool that uses source files such as Docker Compose files or Cloud
 
 ## A quick start with Move2Kube
 
-With Move2Kube, generating the Kubernetes/OpenShift deployment files for your source platform files is now simple. You can try out Move2Kube in [Katacoda](https://move2kube.konveyor.io) or follow the steps mentioned below for trying out Move2Kube on your local machine.
+With Move2Kube, generating the Kubernetes/OpenShift deployment files for your source platform files is now simple. You can follow the steps mentioned below for trying out Move2Kube on your local machine.
 
 
 1. Install Move2Kube

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "move2kube-website",
   "version": "0.3.0",
   "packageManager": "yarn@1.22.19",
-  "description": "This repository holds the code that generates the Move2Kube Project's web page https://movekube.konveyor.io/",
+  "description": "This repository holds the code that generates the Move2Kube Project's web page https://move2kube.konveyor.io/",
   "repository": "https://github.com/konveyor/move2kube",
   "license": "Apache-2.0",
   "bugs": "https://github.com/konveyor/move2kube/issues",


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to broken hyperlinks found in different files. They should point to the official Move2Kube website.